### PR TITLE
API updates

### DIFF
--- a/src/cloogle.ts
+++ b/src/cloogle.ts
@@ -52,7 +52,7 @@ interface cloogleResult_Syntax {
 export async function askCloogle (name) {
     let result: cloogleResults;
     try{
-        let content = await getContent('http://cloogle.org/api.php?str='+encodeURI(name), 'clean-vscode');
+        let content = await getContent('http://cloogle.org/api.php?str='+encodeURI('exact '+name), 'clean-vscode');
         result = JSON.parse(content) as cloogleResults;
     }catch(e){
         console.log('Got error', e);
@@ -64,9 +64,8 @@ let cache = new Map<string,cloogleResult>();
 export let askCloogleExact = async (name) => {
     if(cache.has(name))
         return cache.get(name);
-    let first = (await askCloogle(name))[0];
-    let result = (!first || first[1][0].distance!=-100) ? undefined : first;
-    cache.set(name, result);            
+    let result = (await askCloogle(name))[0];
+    cache.set(name, result);
     return result;
 }
 export let getInterestingStringFrom = ([typeData, [general, specs]]: cloogleResult): string|string[] => 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,7 +38,7 @@ export function activate(context: ExtensionContext) {
                     return new Hover({value: ':: '+varName, language: 'clean'});
                 
                 let link = (line: number, icl=false) => 
-                    `https://cloogle.org/src#${GeneralData.library}.${GeneralData.modul}${icl ? ';icl' : ''};line=${line}`;
+                    `https://cloogle.org/src#${GeneralData.library}/${GeneralData.modul.replace(/\./g,'/')}${icl ? ';icl' : ''};line=${line}`;
                 let head = new MarkdownString(
                     `[[+]](https://cloogle.org/#${encodeURI(varName)}) ${GeneralData.library}: ${GeneralData.modul} ([dcl:${GeneralData.dcl_line}](${link(GeneralData.dcl_line)}):[icl:${GeneralData.icl_line}](${link(GeneralData.icl_line, true)}))`
                 );


### PR DESCRIPTION
I had a look at this plugin and it seems it was still firing requests, but no hovers were created.

- It is not reliable to check if the distance is -100 to know if something is an exact result. For this, you should check whether the name of the result matches. However, I now added a `exact X` kind of query (https://gitlab.science.ru.nl/cloogle/cloogle-org/commit/3012a64f806a2b2680746f67dd2aa6e1ae6e6559) which will only return exact results. (Some exact queries still return multiple results, like `exact Text`. The plugin now still picks an arbitrary result. You could choose to show all results. However, I think you're not using this yourself any more so that would be too much work?)
- In `/src`, we now use slashes instead of periods to separate library and module names.

Should you choose to merge this, it would be nice if you could also update the version in the extension registry. I wouldn't know how to do that.