### PR TITLE
Fix tokenizer issue

### DIFF
--- a/syntaxes/clean.tmLanguage.json
+++ b/syntaxes/clean.tmLanguage.json
@@ -122,7 +122,7 @@
 		}]},
 		"cleanTypeDef": {"patterns": [{
 			"name": "keyword.operator.clean",
-			"match": "^\\s*::\\s*\\u\\w*`?`"
+			"match": "^::\\s*[.*]\\?[A-Z_][a-zA-Z0-9_`]"
 		}]},
 		"cleanLambda": {"patterns": [{
 			"match": "(\\\\)\\s*(([a-zA-Z_]\\w*`?\\s*)+)(\\.|-\\>|=)",


### PR DESCRIPTION
A regression in a VSCode lib broke the syntax highlighting. This is a workaround for this issue.

Regex is based on vim-clean, I haven't tested it properly, but at least it gets the extension working again.